### PR TITLE
CTS Upload Groovy

### DIFF
--- a/resources/metadata/transportRequestUploadCTS.yaml
+++ b/resources/metadata/transportRequestUploadCTS.yaml
@@ -115,7 +115,7 @@ spec:
           - PARAMETERS
       - name: deployToolDependencies
         type: "[]string"
-        default: ['@ui5/cli','@sap/ux-ui5-tooling','@ui5/logger','@ui5/fs']
+        default: ['@ui5/cli', '@sap/ux-ui5-tooling', '@ui5/logger', '@ui5/fs']
         description: "List of additional dependencies to fiori related packages needed to install on a standard node docker image. Provide an empty list, in case your docker image already contains the required dependencies. Caused hereby installing additional dependencies will be skipped"
         aliases:
           - name: changeManagement/deployToolDependencies

--- a/test/groovy/CommonStepsTest.groovy
+++ b/test/groovy/CommonStepsTest.groovy
@@ -194,6 +194,7 @@ public class CommonStepsTest extends BasePiperTest{
         'transportRequestUploadRFC', //implementing new golang pattern without fields
         'writePipelineEnv', //implementing new golang pattern without fields
         'readPipelineEnv', //implementing new golang pattern without fields
+        'transportRequestUploadCTS', //implementing new golang pattern without fields
     ]
 
     @Test

--- a/test/groovy/TransportRequestUploadCTSTest.groovy
+++ b/test/groovy/TransportRequestUploadCTSTest.groovy
@@ -1,0 +1,65 @@
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+import org.junit.rules.RuleChain
+import org.yaml.snakeyaml.parser.ParserException
+
+import hudson.AbortException
+import util.BasePiperTest
+import util.JenkinsDockerExecuteRule
+import util.JenkinsLoggingRule
+import util.JenkinsReadYamlRule
+import util.JenkinsShellCallRule
+import util.JenkinsStepRule
+import util.JenkinsWriteFileRule
+import util.Rules
+
+import static org.hamcrest.Matchers.*
+import static org.junit.Assert.assertThat
+import static org.hamcrest.Matchers.hasEntry
+
+public class TransportRequestUploadCTSTest extends BasePiperTest {
+
+    private JenkinsStepRule stepRule = new JenkinsStepRule(this)
+    private JenkinsReadYamlRule readYamlRule = new JenkinsReadYamlRule(this)
+
+    @Rule
+    public RuleChain ruleChain = Rules
+        .getCommonRules(this)
+        .around(stepRule)
+        .around(readYamlRule)
+
+    @Test
+    void testCallGoWrapper() {
+
+        def calledWithParameters,
+            calledWithStepName,
+            calledWithMetadata
+        List calledWithCredentials
+
+        helper.registerAllowedMethod(
+            'piperExecuteBin',
+            [Map, String, String, List],
+            {
+                params, stepName, metaData, creds ->
+                calledWithParameters = params
+                calledWithStepName = stepName
+                calledWithMetadata = metaData
+                calledWithCredentials = creds
+            }
+        )
+
+        stepRule.step.transportRequestUploadCTS(script: nullScript, abc: 'CF')
+
+        assertThat(calledWithParameters.size(), is(2))
+        assertThat(calledWithParameters.script, is(nullScript))
+        assertThat(calledWithParameters.abc, is('CF'))
+
+        assertThat(calledWithStepName, is('transportRequestUploadCTS'))
+        assertThat(calledWithMetadata, is('metadata/transportRequestUploadCTS.yaml'))
+        assertThat(calledWithCredentials[0].size(), is(3))
+        assertThat(calledWithCredentials[0], allOf(hasEntry('type','usernamePassword'), hasEntry('id','uploadCredentialsId'), hasEntry('env',['PIPER_username', 'PIPER_password'])))
+    }
+}

--- a/vars/transportRequestUploadCTS.groovy
+++ b/vars/transportRequestUploadCTS.groovy
@@ -1,0 +1,17 @@
+import com.sap.piper.BuildTool
+import groovy.transform.Field
+import static com.sap.piper.Prerequisites.checkScript
+import com.sap.piper.DownloadCacheUtils
+
+@Field String STEP_NAME = getClass().getName()
+@Field String METADATA_FILE = 'metadata/transportRequestUploadCTS.yaml'
+
+void call(Map parameters = [:]) {
+    final script = checkScript(this, parameters) ?: this
+    parameters = DownloadCacheUtils.injectDownloadCacheInParameters(script, parameters, BuildTool.NPM)
+
+    List credentials = [
+        [type: 'usernamePassword', id: 'uploadCredentialsId', env: ['PIPER_username', 'PIPER_password']]
+    ]
+    piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
+}


### PR DESCRIPTION
This PR adds the Groovy wrapper of the step transportRequestUploadCTS for the GO commands of #2969 .

Scope: Groovy code only
Risk: low

- [x] Tests
- [ ] Documentation
